### PR TITLE
feat: do not replace agent string with function, add separate property instead

### DIFF
--- a/example/github.ts
+++ b/example/github.ts
@@ -114,8 +114,9 @@ const response = await execute(githubProjectHealthAnalysisFlow, {
     communicationAgent,
   },
   onFlowStart: (flow) => {
-    if (flow.name) {
-      console.log('Executing', flow.name)
+    console.log('Flow started', flow.agent.name)
+    if (flow.agent.name) {
+      console.log('Executing', flow.agent.name)
     }
   },
 })

--- a/packages/flows-ai/src/flows.ts
+++ b/packages/flows-ai/src/flows.ts
@@ -5,11 +5,11 @@
 import { type FlowDefinition } from './index.js'
 
 export function sequence(input: FlowDefinition[], name?: string) {
-  return { input, agent: 'sequenceAgent', name: name ?? 'sequence' }
+  return { input, agent: 'sequenceAgent', name }
 }
 
 export function parallel(input: FlowDefinition[], name?: string) {
-  return { input, agent: 'parallelAgent', name: name ?? 'parallel' }
+  return { input, agent: 'parallelAgent', name }
 }
 
 type RouterProps = {
@@ -22,7 +22,7 @@ export function oneOf(input: RouterProps, name?: string) {
     input: input.map((value) => value.input),
     conditions: input.map((value) => value.when),
     agent: 'oneOfAgent',
-    name: name ?? 'oneOf',
+    name,
   }
 }
 
@@ -33,7 +33,7 @@ type EvaluatorProps = {
 }
 
 export function evaluator(props: EvaluatorProps, name?: string) {
-  return { ...props, agent: 'optimizeAgent', name: name ?? 'evaluator' }
+  return { ...props, agent: 'optimizeAgent', name }
 }
 
 type ForEachProps = {
@@ -42,7 +42,7 @@ type ForEachProps = {
 }
 
 export function forEach(props: ForEachProps, name?: string) {
-  return { ...props, agent: 'forEachAgent', name: name ?? 'forEach' }
+  return { ...props, agent: 'forEachAgent', name }
 }
 
 type BestOfFlowProps = {
@@ -51,7 +51,7 @@ type BestOfFlowProps = {
 }
 
 export function bestOfAll(props: BestOfFlowProps, name?: string) {
-  return { ...props, agent: 'bestOfAllAgent', name: name ?? 'bestOfAll' }
+  return { ...props, agent: 'bestOfAllAgent', name }
 }
 
 /**

--- a/packages/flows-ai/src/index.ts
+++ b/packages/flows-ai/src/index.ts
@@ -14,7 +14,7 @@ import {
 
 /**
  * Helper type to hydrate the flow definition.
- * For each `agent` present, we put `run` property that will run it with its input.
+ * This is what is done when we call `hydrate`.
  */
 type Hydrated<T> = T extends object
   ? {
@@ -53,7 +53,8 @@ export type FlowDefinition = {
 /**
  * Flow is a hydrated version of FlowDefinition.
  *
- * The flow will have `run` property that will execute given agent with its input.
+ * The difference here is that `agent` is now a function, instead of a string.
+ * In the future, we will perform validation here.
  */
 export type Flow = Hydrated<FlowDefinition>
 


### PR DESCRIPTION
We set the name on the function, so we will be able to easily serialize it later into JSON when we start doing asynchronous/events and interruptions.