### PR TITLE
Use 'evaluator' rather than 'evaluate' in docs

### DIFF
--- a/docs/src/content/docs/flows/evaluator.mdx
+++ b/docs/src/content/docs/flows/evaluator.mdx
@@ -39,9 +39,9 @@ Maximum number of iterations to attempt improvement.
 ## Example
 
 ```ts collapse={12-40}
-import { evaluate } from 'flows-ai/flows'
+import { evaluator } from 'flows-ai/flows'
 
-const optimizeFlow = evaluate({
+const optimizeFlow = evaluator({
   input: {
     agent: 'writingAgent',
     input: 'Write a compelling story'


### PR DESCRIPTION
A very quick fix — the docs were using `evaluate` rather than `evaluator`.